### PR TITLE
ci(security): add gitleaks scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Full repository scan
+        uses: zricethezav/gitleaks-action@v1
+        with:
+          config-path: .gitleaks.toml
+      - name: Pull request diff scan
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm \
+            -v "$PWD:/repo" \
+            zricethezav/gitleaks:latest detect \
+            --source=/repo \
+            --config=/repo/.gitleaks.toml \
+            --redact \
+            --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+title = "StellarTip secret scanning"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "stellar-secret-key"
+description = "Stellar secret keys start with S and are 56 characters long."
+regex = '''S[A-Z2-7]{55}'''
+tags = ["stellar", "secret-key"]
+
+[allowlist]
+description = "Documented local-only placeholders and deterministic test fixtures."
+regexes = [
+  '''JWT_SECRET=(change-me-to-a-random-secret|test-secret-key|e2e-secret-key)''',
+  "secretOrKey:\\s*configService\\.get<string>\\('JWT_SECRET'\\)\\s*\\|\\|\\s*'your-secret-key'",
+  '''mockReturnValue\('test-access-token'\)''',
+  "password:\\s*'testpass123'",
+  '''DB_PASSWORD=postgres''',
+]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,8 @@
 npx lint-staged
+
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --redact --config .gitleaks.toml
+else
+  echo "gitleaks not installed; skipping staged secret scan"
+  echo "Install gitleaks to run 'gitleaks protect --staged --redact' before commit."
+fi

--- a/docs/SECRET-SCANNING.md
+++ b/docs/SECRET-SCANNING.md
@@ -1,0 +1,50 @@
+# Secret scanning
+
+StellarTip uses Gitleaks to block committed credentials before they reach the
+main branch.
+
+## CI checks
+
+The `Secret Scan` CI job runs on pushes and pull requests. It performs:
+
+- a full repository scan using `.gitleaks.toml`
+- a pull request diff scan when the workflow is triggered by a PR
+
+The job fails when it finds API keys, JWT secrets, private keys, Stellar secret
+keys, or other supported credentials.
+
+## Local pre-commit check
+
+Install Gitleaks locally:
+
+```bash
+brew install gitleaks
+```
+
+or follow the installation guide for your operating system from the Gitleaks
+project.
+
+The Husky pre-commit hook runs:
+
+```bash
+gitleaks protect --staged --redact --config .gitleaks.toml
+```
+
+If Gitleaks is not installed, the hook prints a warning and continues so local
+development is not blocked by a missing optional binary. CI remains the
+enforced gate.
+
+## Allowed placeholders
+
+`.gitleaks.toml` allowlists only deterministic local placeholders and test
+fixtures, including:
+
+- `JWT_SECRET=change-me-to-a-random-secret`
+- `JWT_SECRET=test-secret-key`
+- `JWT_SECRET=e2e-secret-key`
+- `DB_PASSWORD=postgres`
+- deterministic test tokens such as `test-access-token`
+
+Do not add production credentials, wallet private keys, or real API tokens to
+the allowlist. Replace real secrets with environment variables or GitHub
+Actions secrets instead.


### PR DESCRIPTION
## Problem
Secrets such as JWT keys, API tokens, wallet private keys, and Stellar secret keys could be committed without an automated repository gate.

## Solution
- Added `.gitleaks.toml` with default rules plus a Stellar secret-key rule.
- Added a `Secret Scan` CI job that runs the requested `zricethezav/gitleaks-action@v1` full repository scan and a PR diff scan.
- Added a Husky pre-commit staged scan through `gitleaks protect --staged --redact --config .gitleaks.toml` when the local binary is installed.
- Documented local setup, CI behavior, and the narrow placeholder allowlist.

Closes #63

## Verification
- Parsed `.gitleaks.toml` with Python `tomllib`
- `npx.cmd --yes prettier --check .github/workflows/ci.yml docs/SECRET-SCANNING.md`
- `git diff --check`

I could not execute Gitleaks locally because this Windows machine does not have the `gitleaks` binary or Docker installed. The new CI job should exercise the scanner on the branch.