### PR TITLE
feat: add k6 load/performance tests and CI workflow (#71)

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,111 @@
+name: Load Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'test/load/**'
+      - '.github/workflows/load-test.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  load-test:
+    name: k6 Load Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: stellartip_load
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: stellartip_load
+      JWT_SECRET: load-test-secret
+      NODE_ENV: test
+      PORT: 3000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Start API server
+        run: node dist/main.js &
+        env:
+          PORT: 3000
+
+      - name: Wait for API to be ready
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:3000/health && break
+            echo "Waiting for API... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run health smoke test
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: test/load/health-smoke.js
+          flags: --out json=results/health-smoke.json
+        env:
+          BASE_URL: http://localhost:3000
+
+      - name: Run auth rate-limit test
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: test/load/auth-rate-limit.js
+          flags: --out json=results/auth-rate-limit.json
+        env:
+          BASE_URL: http://localhost:3000
+
+      - name: Run tip creation burst test
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: test/load/tip-creation.js
+          flags: --out json=results/tip-creation.json
+        env:
+          BASE_URL: http://localhost:3000
+
+      - name: Run profile reads test
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: test/load/profile-reads.js
+          flags: --out json=results/profile-reads.json
+        env:
+          BASE_URL: http://localhost:3000
+
+      - name: Upload load test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-load-test-results
+          path: results/
+          retention-days: 30

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,66 @@
+# StellarTip API — Performance Baseline
+
+Load and performance testing for the StellarTip Backend API using [k6](https://k6.io/).
+
+## Thresholds
+
+| Metric | Threshold |
+|--------|-----------|
+| p95 response time | < 200ms |
+| Error rate | < 1% |
+
+## Load Envelope
+
+| Script | Endpoint | Target RPS | Duration | Pattern |
+|--------|----------|-----------|----------|---------|
+| `health-smoke.js` | `GET /health` | 1000 RPS | 30s | Constant |
+| `profile-reads.js` | `GET /profiles/:username` | 200 RPS | 5 min | Ramp up → sustain → ramp down |
+| `auth-rate-limit.js` | `POST /auth/login` | ~15 req/VU | 2 min | Per-VU (rate-limit verification) |
+| `tip-creation.js` | `POST /tips` | 50 RPS | 5 min | Ramp up → sustain → ramp down |
+
+## Scripts
+
+All scripts live under `test/load/`.
+
+### `health-smoke.js`
+
+Verifies the liveness endpoint sustains **1000 RPS** for 30 seconds with p95 < 200ms.
+
+### `profile-reads.js`
+
+Simulates read traffic on creator profiles at **200 RPS** for 5 minutes.  
+Ramp-up: 0 → 200 RPS over 30s. Ramp-down: 200 → 0 RPS over 30s.
+
+### `auth-rate-limit.js`
+
+Confirms auth endpoints enforce the **10 req/min** per-IP throttle (`AuthThrottle` decorator).  
+Each VU sends 15 requests (exceeding the 10 req/min limit), and the test asserts that HTTP 429 responses are observed.
+
+### `tip-creation.js`
+
+Burst test for tip creation at **50 RPS** for 5 minutes.  
+Ramp-up: 0 → 50 RPS over 30s. Ramp-down: 50 → 0 RPS over 30s.
+
+## Running Locally
+
+Requires [k6](https://k6.io/docs/get-started/installation/) or Docker.
+
+```bash
+# With k6 installed
+k6 run test/load/health-smoke.js
+
+# With Docker
+docker run --rm -i grafana/k6 run - < test/load/health-smoke.js
+
+# Override base URL
+k6 run --env BASE_URL=http://localhost:3000 test/load/profile-reads.js
+
+# Save JSON output for trend tracking
+k6 run --out json=results.json test/load/tip-creation.js
+```
+
+## CI
+
+The `load-test` GitHub Actions workflow (`.github/workflows/load-test.yml`) runs all scripts against a fresh test stack on every push to `main` that modifies load test files, and on `workflow_dispatch`.
+
+Results are stored as a `k6-load-test-results` artifact (retained 30 days) for trend tracking.

--- a/test/load/auth-rate-limit.js
+++ b/test/load/auth-rate-limit.js
@@ -1,0 +1,44 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Rate } from 'k6/metrics';
+
+const rateLimitedCount = new Counter('auth_rate_limited_requests');
+const rateLimitEnforced = new Rate('auth_rate_limit_enforced');
+
+// Each VU sends 15 requests per minute — expect the 11th+ to be rate-limited
+export const options = {
+  scenarios: {
+    auth_rate_limit: {
+      executor: 'per-vu-iterations',
+      vus: 5,
+      iterations: 15,
+      maxDuration: '2m',
+    },
+  },
+  thresholds: {
+    // At least some requests should be rate-limited (429)
+    auth_rate_limited_requests: ['count>0'],
+    auth_rate_limit_enforced: ['rate>0'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+const params = { headers: { 'Content-Type': 'application/json' } };
+
+export default function () {
+  const payload = JSON.stringify({ email: 'load@test.com', password: 'wrong' });
+  const res = http.post(`${BASE_URL}/auth/login`, payload, params);
+
+  const isRateLimited = res.status === 429;
+  if (isRateLimited) rateLimitedCount.add(1);
+  rateLimitEnforced.add(isRateLimited ? 1 : 0);
+
+  check(res, {
+    'status is 200, 401, or 429': (r) =>
+      r.status === 200 || r.status === 401 || r.status === 429,
+  });
+
+  // ~4 req/s per VU — 10 requests within 60s window triggers rate limit
+  sleep(0.25);
+}

--- a/test/load/health-smoke.js
+++ b/test/load/health-smoke.js
@@ -1,0 +1,34 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const responseTrend = new Trend('health_response_time');
+
+export const options = {
+  scenarios: {
+    health_smoke: {
+      executor: 'constant-arrival-rate',
+      rate: 1000,
+      timeUnit: '1s',
+      duration: '30s',
+      preAllocatedVUs: 100,
+      maxVUs: 200,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<200'],
+    health_response_time: ['p(95)<200'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+export default function () {
+  const res = http.get(`${BASE_URL}/health`);
+  responseTrend.add(res.timings.duration);
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response time < 200ms': (r) => r.timings.duration < 200,
+  });
+}

--- a/test/load/profile-reads.js
+++ b/test/load/profile-reads.js
@@ -1,0 +1,41 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const responseTrend = new Trend('profile_read_response_time');
+
+export const options = {
+  scenarios: {
+    profile_reads: {
+      executor: 'constant-arrival-rate',
+      rate: 200,
+      timeUnit: '1s',
+      duration: '5m',
+      preAllocatedVUs: 50,
+      maxVUs: 100,
+      startRate: 0,
+      stages: [
+        { target: 200, duration: '30s' },
+        { target: 200, duration: '4m' },
+        { target: 0, duration: '30s' },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<200'],
+    profile_read_response_time: ['p(95)<200'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const TEST_USERNAME = __ENV.TEST_USERNAME || 'testcreator';
+
+export default function () {
+  const res = http.get(`${BASE_URL}/profiles/${TEST_USERNAME}`);
+  responseTrend.add(res.timings.duration);
+  check(res, {
+    'status is 200 or 404': (r) => r.status === 200 || r.status === 404,
+    'response time < 200ms': (r) => r.timings.duration < 200,
+  });
+}

--- a/test/load/tip-creation.js
+++ b/test/load/tip-creation.js
@@ -1,0 +1,50 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const responseTrend = new Trend('tip_creation_response_time');
+
+export const options = {
+  scenarios: {
+    tip_burst: {
+      executor: 'constant-arrival-rate',
+      rate: 50,
+      timeUnit: '1s',
+      duration: '5m',
+      preAllocatedVUs: 20,
+      maxVUs: 60,
+      startRate: 0,
+      stages: [
+        { target: 50, duration: '30s' },
+        { target: 50, duration: '4m' },
+        { target: 0, duration: '30s' },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<200'],
+    tip_creation_response_time: ['p(95)<200'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+const params = { headers: { 'Content-Type': 'application/json' } };
+
+export default function () {
+  const payload = JSON.stringify({
+    receiverWallet: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    senderWallet: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    amount: 1,
+    asset: 'XLM',
+    message: 'k6 load test',
+  });
+
+  const res = http.post(`${BASE_URL}/tips`, payload, params);
+  responseTrend.add(res.timings.duration);
+  check(res, {
+    'status is 201 or 429': (r) => r.status === 201 || r.status === 429,
+    'response time < 200ms': (r) => r.timings.duration < 200,
+  });
+}


### PR DESCRIPTION
## Summary

Closes #71

Adds k6 load/performance tests to establish API throughput baselines and catch regressions in CI.

## Changes

### Load Test Scripts (`test/load/`)

| Script | Endpoint | Target | Duration |
|--------|----------|--------|----------|
| `health-smoke.js` | `GET /health` | 1000 RPS | 30s |
| `profile-reads.js` | `GET /profiles/:username` | 200 RPS | 5 min |
| `auth-rate-limit.js` | `POST /auth/login` | 15 req/VU | 2 min |
| `tip-creation.js` | `POST /tips` | 50 RPS | 5 min |

All scripts use `check()` and `Trend` metrics from k6, output to JSON for trend tracking, and apply ramp-up/down phases where applicable.

### CI Workflow (`.github/workflows/load-test.yml`)

- Uses `grafana/k6-action@v0.3.1` (Docker-based k6)
- Spins up a fresh Postgres + API stack
- Runs all 4 scripts sequentially
- Uploads results as `k6-load-test-results` artifact (retained 30 days)
- Triggered on push to `main` (load test file changes) and `workflow_dispatch`

### Documentation (`docs/PERFORMANCE.md`)

Documents the load envelope, thresholds, and local/CI usage instructions.

## Thresholds

- p95 response time < 200ms
- Error rate < 1%