### PR TITLE
feat(ops): database backup/restore scripts and runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 1 1,4,7,10 *' # quarterly disaster-recovery-test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -141,3 +144,51 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+
+  disaster-recovery-test:
+    name: Disaster Recovery Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Run quarterly: first day of Jan, Apr, Jul, Oct — or on manual dispatch
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule')
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: stellartip_dr
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: stellartip_dr
+      BACKUP_ENCRYPTION_KEY: ${{ secrets.BACKUP_ENCRYPTION_KEY }}
+      S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
+      S3_PREFIX: backups
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install PostgreSQL client
+        run: sudo apt-get install -y postgresql-client
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Make scripts executable
+        run: chmod +x scripts/backup.sh scripts/restore.sh scripts/test-restore.sh
+      - name: Run backup
+        run: ./scripts/backup.sh
+      - name: Run test-restore
+        run: ./scripts/test-restore.sh

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,151 @@
+# Database Backup & Restore Runbook
+
+This document describes the backup strategy, recovery procedures, and SLA targets for the StellarTip production database.
+
+## Recovery Targets
+
+| Target                         | Value          | Notes                                                                      |
+| ------------------------------ | -------------- | -------------------------------------------------------------------------- |
+| RPO (Recovery Point Objective) | **1 hour**     | Maximum data loss window; met by daily full backups + 15-min WAL archiving |
+| RTO (Recovery Time Objective)  | **15 minutes** | Time to restore service after declaring an incident                        |
+
+## Backup Schedule
+
+| Type                                      | Frequency        | Time       | Retention |
+| ----------------------------------------- | ---------------- | ---------- | --------- |
+| Full snapshot (`pg_dump --format=custom`) | Daily            | 02:00 UTC  | 30 days   |
+| WAL archiving (`archive_command`)         | Every 15 minutes | Continuous | 7 days    |
+
+### Cron (production server)
+
+```cron
+0 2 * * * /opt/stellartip/scripts/backup.sh >> /var/log/stellartip-backup.log 2>&1
+```
+
+## Required Environment Variables
+
+| Variable                | Description                                       |
+| ----------------------- | ------------------------------------------------- |
+| `DB_HOST`               | PostgreSQL host                                   |
+| `DB_PORT`               | PostgreSQL port (default `5432`)                  |
+| `DB_USERNAME`           | Database user                                     |
+| `DB_PASSWORD`           | Database password                                 |
+| `DB_NAME`               | Database name                                     |
+| `BACKUP_ENCRYPTION_KEY` | AES-256 passphrase for encrypting backups at rest |
+| `S3_BUCKET`             | S3 bucket for offsite storage                     |
+| `S3_PREFIX`             | Object key prefix (default `backups`)             |
+| `RETENTION_DAYS`        | Days to keep S3 objects (default `30`)            |
+
+> Store `BACKUP_ENCRYPTION_KEY` in AWS Secrets Manager or equivalent. Never commit it to the repository.
+
+## Backup Script (`scripts/backup.sh`)
+
+1. Runs `pg_dump --format=custom --jobs=4` (compressed, parallel-capable).
+2. Encrypts the dump with AES-256-CBC (PBKDF2, 100 000 iterations) via `openssl enc`.
+3. Uploads to `s3://$S3_BUCKET/$S3_PREFIX/stellartip-YYYY-MM-DD-HHMM.dump.enc` using `STANDARD_IA` storage class.
+4. Deletes the local plaintext and encrypted files.
+5. Prunes S3 objects older than `RETENTION_DAYS` (default 30 days).
+
+```bash
+# Manual run
+export DB_HOST=... DB_USERNAME=... DB_PASSWORD=... DB_NAME=...
+export BACKUP_ENCRYPTION_KEY=... S3_BUCKET=stellartip-backups
+./scripts/backup.sh
+```
+
+## Restore Script (`scripts/restore.sh`)
+
+Accepts a local file path or an `s3://` URI, plus an optional target database name.
+
+```bash
+# From S3
+./scripts/restore.sh s3://stellartip-backups/backups/stellartip-2026-06-20-0200.dump.enc stellartip_restored
+
+# From local file
+./scripts/restore.sh /tmp/stellartip-2026-06-20-0200.dump.enc
+```
+
+Steps performed:
+
+1. Downloads from S3 (if URI given) to a temp directory.
+2. Decrypts with `openssl enc -d`.
+3. Drops and recreates the target database.
+4. Runs `pg_restore --jobs=4 --no-owner --no-privileges`.
+5. Cleans up temp files via trap.
+
+## Test-Restore Script (`scripts/test-restore.sh`)
+
+Verifies a backup is restorable and contains data. Run quarterly (also automated in CI).
+
+```bash
+# Use latest S3 backup automatically
+./scripts/test-restore.sh
+
+# Specify a backup explicitly
+./scripts/test-restore.sh s3://stellartip-backups/backups/stellartip-2026-06-20-0200.dump.enc
+```
+
+Steps:
+
+1. Resolves the latest S3 backup if no argument is given.
+2. Calls `restore.sh` into a temporary `stellartip_restore_test` database.
+3. Queries row counts for every table in the `public` schema.
+4. Warns on empty tables.
+5. Drops the test database.
+6. Exits 0 on success, non-zero on any failure.
+
+## WAL Archiving Setup
+
+Add to `postgresql.conf`:
+
+```ini
+wal_level = replica
+archive_mode = on
+archive_command = 'aws s3 cp %p s3://${S3_BUCKET}/wal/%f'
+archive_timeout = 900   # 15 minutes
+```
+
+## Disaster Recovery Procedure
+
+1. **Declare incident** — notify on-call, open incident channel.
+2. **Identify target restore point** — latest snapshot or specific timestamp.
+3. **Provision or clear target DB** — restore.sh handles DROP + CREATE automatically.
+4. **Run restore**:
+   ```bash
+   ./scripts/restore.sh s3://stellartip-backups/backups/<filename>.dump.enc
+   ```
+5. **Verify** — run `test-restore.sh` or spot-check row counts manually.
+6. **Update connection strings** if restoring to a new host.
+7. **Replay WAL** (if finer point-in-time recovery needed) using `pg_waldump` / PITR.
+8. **Resume traffic** — update load balancer / DNS.
+9. **Post-incident review** — document timeline and root cause within 48 hours.
+
+## S3 Bucket Policy (Recommended)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyPublicAccess",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::stellartip-backups/*",
+      "Condition": {
+        "StringNotEquals": { "aws:PrincipalAccount": "<account-id>" }
+      }
+    }
+  ]
+}
+```
+
+Enable S3 Versioning and Object Lock (compliance mode, 30-day retention) on the bucket.
+
+## Testing Checklist (Quarterly)
+
+- [ ] CI `disaster-recovery-test` job passed (automated)
+- [ ] Encryption key accessible from production secrets store
+- [ ] S3 retention policy active (objects > 30 days deleted)
+- [ ] RTO drill: restore completed within 15 minutes
+- [ ] WAL archiving lag < 15 minutes

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# scripts/backup.sh — PostgreSQL backup with AES-256 encryption and S3 upload
+# Usage: ./scripts/backup.sh
+# Env: DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_NAME,
+#      BACKUP_ENCRYPTION_KEY, S3_BUCKET, S3_PREFIX (optional), BACKUP_DIR (optional)
+set -euo pipefail
+
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_USERNAME="${DB_USERNAME:-postgres}"
+DB_NAME="${DB_NAME:-stellartip}"
+BACKUP_DIR="${BACKUP_DIR:-/tmp/stellartip-backups}"
+S3_PREFIX="${S3_PREFIX:-backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+TIMESTAMP="$(date -u '+%Y-%m-%d-%H%M')"
+DUMP_FILE="${BACKUP_DIR}/stellartip-${TIMESTAMP}.dump"
+ENC_FILE="${DUMP_FILE}.enc"
+
+: "${BACKUP_ENCRYPTION_KEY:?BACKUP_ENCRYPTION_KEY must be set}"
+: "${S3_BUCKET:?S3_BUCKET must be set}"
+
+mkdir -p "${BACKUP_DIR}"
+
+echo "[backup] Starting pg_dump for ${DB_NAME} at ${TIMESTAMP}"
+PGPASSWORD="${DB_PASSWORD:-}" pg_dump \
+  --host="${DB_HOST}" \
+  --port="${DB_PORT}" \
+  --username="${DB_USERNAME}" \
+  --format=custom \
+  --jobs=4 \
+  --file="${DUMP_FILE}" \
+  "${DB_NAME}"
+
+echo "[backup] Encrypting with AES-256"
+openssl enc -aes-256-cbc -pbkdf2 -iter 100000 \
+  -pass "pass:${BACKUP_ENCRYPTION_KEY}" \
+  -in "${DUMP_FILE}" -out "${ENC_FILE}"
+rm -f "${DUMP_FILE}"
+
+echo "[backup] Uploading to s3://${S3_BUCKET}/${S3_PREFIX}/stellartip-${TIMESTAMP}.dump.enc"
+aws s3 cp "${ENC_FILE}" \
+  "s3://${S3_BUCKET}/${S3_PREFIX}/stellartip-${TIMESTAMP}.dump.enc" \
+  --storage-class STANDARD_IA
+
+echo "[backup] Removing local encrypted file"
+rm -f "${ENC_FILE}"
+
+echo "[backup] Pruning S3 objects older than ${RETENTION_DAYS} days"
+CUTOFF="$(date -u -d "${RETENTION_DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ')"
+aws s3api list-objects-v2 \
+  --bucket "${S3_BUCKET}" \
+  --prefix "${S3_PREFIX}/" \
+  --query "Contents[?LastModified<='${CUTOFF}'].Key" \
+  --output text | tr '\t' '\n' | while read -r key; do
+    [ -z "${key}" ] && continue
+    echo "[backup] Deleting old object: ${key}"
+    aws s3api delete-object --bucket "${S3_BUCKET}" --key "${key}"
+done
+
+echo "[backup] Done — stellartip-${TIMESTAMP}.dump.enc"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# scripts/restore.sh — Decrypt and restore a PostgreSQL backup
+# Usage: ./scripts/restore.sh <backup-file-or-s3-uri> [target-db]
+# Env: DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, BACKUP_ENCRYPTION_KEY
+set -euo pipefail
+
+BACKUP_SRC="${1:?Usage: $0 <backup-file-or-s3-uri> [target-db]}"
+TARGET_DB="${2:-${DB_NAME:-stellartip}}"
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_USERNAME="${DB_USERNAME:-postgres}"
+WORK_DIR="$(mktemp -d)"
+ENC_FILE="${WORK_DIR}/backup.dump.enc"
+DUMP_FILE="${WORK_DIR}/backup.dump"
+
+: "${BACKUP_ENCRYPTION_KEY:?BACKUP_ENCRYPTION_KEY must be set}"
+
+cleanup() { rm -rf "${WORK_DIR}"; }
+trap cleanup EXIT
+
+# Download from S3 if URI provided
+if [[ "${BACKUP_SRC}" == s3://* ]]; then
+  echo "[restore] Downloading ${BACKUP_SRC}"
+  aws s3 cp "${BACKUP_SRC}" "${ENC_FILE}"
+else
+  cp "${BACKUP_SRC}" "${ENC_FILE}"
+fi
+
+echo "[restore] Decrypting backup"
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 100000 \
+  -pass "pass:${BACKUP_ENCRYPTION_KEY}" \
+  -in "${ENC_FILE}" -out "${DUMP_FILE}"
+
+echo "[restore] Dropping and recreating database: ${TARGET_DB}"
+PGPASSWORD="${DB_PASSWORD:-}" psql \
+  --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USERNAME}" \
+  --dbname=postgres -c "DROP DATABASE IF EXISTS \"${TARGET_DB}\";"
+PGPASSWORD="${DB_PASSWORD:-}" psql \
+  --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USERNAME}" \
+  --dbname=postgres -c "CREATE DATABASE \"${TARGET_DB}\";"
+
+echo "[restore] Restoring into ${TARGET_DB}"
+PGPASSWORD="${DB_PASSWORD:-}" pg_restore \
+  --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USERNAME}" \
+  --dbname="${TARGET_DB}" --jobs=4 --no-owner --no-privileges \
+  "${DUMP_FILE}"
+
+echo "[restore] Done — ${TARGET_DB} restored from $(basename "${BACKUP_SRC}")"

--- a/scripts/test-restore.sh
+++ b/scripts/test-restore.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# scripts/test-restore.sh — Restore latest backup to a fresh DB and verify row counts
+# Usage: ./scripts/test-restore.sh [s3-uri]
+# Env: DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, BACKUP_ENCRYPTION_KEY, S3_BUCKET, S3_PREFIX
+set -euo pipefail
+
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_USERNAME="${DB_USERNAME:-postgres}"
+S3_PREFIX="${S3_PREFIX:-backups}"
+TEST_DB="stellartip_restore_test"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${BACKUP_ENCRYPTION_KEY:?BACKUP_ENCRYPTION_KEY must be set}"
+
+# Resolve backup source: explicit arg or latest from S3
+if [ -n "${1:-}" ]; then
+  BACKUP_SRC="${1}"
+else
+  : "${S3_BUCKET:?S3_BUCKET must be set when no backup file is given}"
+  echo "[test-restore] Resolving latest backup from s3://${S3_BUCKET}/${S3_PREFIX}/"
+  BACKUP_SRC="s3://${S3_BUCKET}/$(aws s3api list-objects-v2 \
+    --bucket "${S3_BUCKET}" --prefix "${S3_PREFIX}/" \
+    --query 'sort_by(Contents,&LastModified)[-1].Key' \
+    --output text)"
+fi
+
+echo "[test-restore] Source: ${BACKUP_SRC}"
+
+# Restore into throw-away database
+DB_NAME="${TEST_DB}" "${SCRIPT_DIR}/restore.sh" "${BACKUP_SRC}" "${TEST_DB}"
+
+echo "[test-restore] Verifying row counts"
+PGPASSWORD="${DB_PASSWORD:-}" psql \
+  --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USERNAME}" \
+  --dbname="${TEST_DB}" --tuples-only --no-align \
+  -c "SELECT tablename FROM pg_tables WHERE schemaname='public';" \
+  | while read -r table; do
+      [ -z "${table}" ] && continue
+      count=$(PGPASSWORD="${DB_PASSWORD:-}" psql \
+        --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USERNAME}" \
+        --dbname="${TEST_DB}" --tuples-only --no-align \
+        -c "SELECT COUNT(*) FROM \"${table}\";")
+      echo "[test-restore]   ${table}: ${count} rows"
+      if [ "${count}" -eq 0 ]; then
+        echo "[test-restore] WARNING: ${table} is empty — manual review recommended"
+      fi
+  done
+
+echo "[test-restore] Cleaning up test database"
+PGPASSWORD="${DB_PASSWORD:-}" psql \
+  --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USERNAME}" \
+  --dbname=postgres -c "DROP DATABASE IF EXISTS \"${TEST_DB}\";"
+
+echo "[test-restore] PASSED"


### PR DESCRIPTION
## Summary

Implements automated PostgreSQL backup/restore infrastructure for production.

### Changes
- **`scripts/backup.sh`** — `pg_dump --format=custom` (parallel), AES-256-CBC encryption, S3 upload, 30-day retention cleanup
- **`scripts/restore.sh`** — decrypts and restores from S3 URI or local file into a target DB
- **`scripts/test-restore.sh`** — restores latest backup to a temp DB, verifies row counts across all tables, drops it
- **`docs/BACKUP.md`** — full runbook: schedule, RPO/RTO targets, WAL archiving config, DR procedure, S3 bucket policy
- **`ci.yml`** — `disaster-recovery-test` job (quarterly cron + `workflow_dispatch`)

### Acceptance Criteria Met
- [x] `pg_dump --format=custom` (compressed, parallel with `--jobs=4`)
- [x] `restore.sh` accepts backup file/S3 URI and optional target DB
- [x] Daily full snapshot @ 02:00 UTC + WAL archiving every 15 min documented
- [x] RPO 1 hour / RTO 15 minutes documented
- [x] S3 upload with AWS CLI
- [x] 30-day retention with automatic cleanup
- [x] AES-256 encryption before S3 upload
- [x] `test-restore.sh` restores to fresh DB and verifies row counts
- [x] `disaster-recovery-test` CI job (quarterly)

### Required Secrets
Add to GitHub repository secrets:
`BACKUP_ENCRYPTION_KEY`, `BACKUP_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`

Closes #58