### PR TITLE
deps: add Dependabot config for automated dependency update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: deps
+    groups:
+      nestjs-ecosystem:
+        patterns:
+          - '@nestjs/*'
+          - 'nest-*'
+      stellar:
+        patterns:
+          - '@stellar/*'
+          - 'stellar-*'
+      dev-tools:
+        patterns:
+          - 'eslint*'
+          - '@eslint/*'
+          - 'prettier*'
+          - 'typescript*'
+          - '@typescript-eslint/*'
+          - 'husky'
+          - 'lint-staged'
+          - 'jest'
+          - '@types/*'
+          - 'ts-*'
+          - '@swc/*'
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: deps
+    labels:
+      - dependencies

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,53 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch updates
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add changelog summary comment
+        if: steps.metadata.outputs.update-type != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const depName = '${{ steps.metadata.outputs.dependency-names }}';
+            const updateType = '${{ steps.metadata.outputs.update-type }}';
+            const prevVersion = '${{ steps.metadata.outputs.previous-version }}';
+            const newVersion = '${{ steps.metadata.outputs.new-version }}';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## Dependabot Update Summary\n\n| Field | Value |\n|---|---|\n| **Package** | \`${depName}\` |\n| **Update type** | \`${updateType}\` |\n| **Previous version** | \`${prevVersion}\` |\n| **New version** | \`${newVersion}\` |\n\nReview the [changelog](${pr.body ?? ''}) before merging minor or major bumps.`,
+            });
+
+      - name: Auto-merge patch-level updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          (steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' ||
+           steps.metadata.outputs.package-ecosystem == 'github_actions')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,32 @@ src/
 └── main.ts         # Application entrypoint
 ```
 
+## Dependency Management
+
+We use [Dependabot](https://docs.github.com/en/code-security/dependabot) to keep npm and GitHub Actions dependencies up to date automatically.
+
+### Schedule
+
+Dependabot opens PRs every **Monday at 09:00 UTC**. Related packages are batched into groups so you won't see a flood of individual PRs:
+
+| Group | Packages |
+|---|---|
+| `nestjs-ecosystem` | `@nestjs/*`, `nest-*` |
+| `stellar` | `@stellar/*`, `stellar-*` |
+| `dev-tools` | ESLint, Prettier, TypeScript, Jest, Husky, lint-staged, `@types/*`, ts-\* |
+
+A maximum of **10 open Dependabot PRs** are allowed at any time.
+
+### Review requirements
+
+| Semver bump | Action required |
+|---|---|
+| **patch** | Auto-merged by CI after all checks pass — no review needed |
+| **minor** | Requires one team member review; check the changelog summary comment left by the bot |
+| **major** | Requires two team member reviews; assess breaking changes and update code accordingly before merging |
+
+All Dependabot PRs use the `deps` conventional-commit prefix (e.g. `deps: bump @nestjs/common from 11.0.1 to 11.1.0`).
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Implements automated dependency management via Dependabot as requested in #80.

## Changes

- `.github/dependabot.yml` — weekly schedule (Mondays 09:00 UTC), grouped updates for `nestjs-ecosystem`, `stellar`, and `dev-tools`, max 10 open PRs, `deps` commit prefix. Covers both npm and GitHub Actions ecosystems.
- `.github/workflows/dependabot-auto-merge.yml` — uses `dependabot/fetch-metadata@v2` to post a changelog summary comment on every Dependabot PR, then auto-merges patch-level updates via `gh pr merge --auto --squash`.
- `CONTRIBUTING.md` — documents the dependency review policy: patch = auto-merge, minor = 1 review, major = 2 reviews.

## Testing

Dependabot will open its first batch of PRs on the next Monday after this merges. A known-outdated dep PR will confirm the config is active.

Closes #80